### PR TITLE
fix: make tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,11 @@ push: ## Push all 'push' to registry
 _tidy:
 	bazel run @rules_go//go -- mod tidy
 
-tidy: link _tidy unlink ## Run go mod tidy
-	
+tidy: ## Run go mod tidy
+	$(MAKE) link
+	$(MAKE) _tidy
+	$(MAKE) unlink
+
 test: ## Run test
 	bash ci/test.sh
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Makefile-only change to developer workflow; no runtime or production behavior.
> 
> **Overview**
> **Fixes the `tidy` Make target** so `go mod tidy` runs in the right order with Bazel-linked protos.
> 
> Previously `tidy` only listed `link`, `_tidy`, and `unlink` as dependencies (with an empty or broken recipe). It now **runs those steps explicitly** via `$(MAKE) link`, `$(MAKE) _tidy`, and `$(MAKE) unlink`, so link → tidy → unlink happens reliably before/after proto symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fad465d2d08abf3486d61766e3b5ec9bfcc31ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->