### PR TITLE
Bump GitHub Actions deps (checkout, setup-bazel, upload-artifact)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
         uses: hrishikesh-kadam/setup-lcov@v1
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.15.0
+        uses: bazel-contrib/setup-bazel@0.18.0
         with:
           # Avoid downloading Bazel every time.
           bazelisk-cache: true
@@ -28,7 +28,7 @@ jobs:
           # Share repository cache between workflows.
           repository-cache: true
 
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
 
       - name: Test
         run: make test
@@ -40,7 +40,7 @@ jobs:
         run: make coverage
 
       - name: Publish code cov
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: code covarege report
           path: genhtml/


### PR DESCRIPTION
## Summary

Bundles the three open GitHub Actions Dependabot bumps into one PR. All changes are in `.github/workflows/go.yml`.

| Action | From | To | Dependabot |
|---|---|---|---|
| `bazel-contrib/setup-bazel` | 0.15.0 | 0.18.0 | #159 |
| `actions/checkout` | v5.0.0 | v6.0.2 | #161 |
| `actions/upload-artifact` | v5 | v6 | #153 |

These are the GitHub Actions bumps that were intentionally left out of #167 (which covered the Go module / Bazel deps). The `checkout` and `upload-artifact` major bumps are primarily Node runtime upgrades (node24); `setup-bazel`'s `bazelisk-cache` / `disk-cache` / `repository-cache` inputs are unchanged.

### Supersedes
- #159, #161, #153 — close these once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency bumps with unchanged workflow steps and inputs; risk is limited to possible action breaking changes on the next workflow run.
> 
> **Overview**
> Updates the **Go CI workflow** (`.github/workflows/go.yml`) to newer pinned versions of three third-party actions, with no changes to step inputs or `make` commands.
> 
> **`bazel-contrib/setup-bazel`** moves from `0.15.0` to `0.18.0`; cache-related `with` options (`bazelisk-cache`, `disk-cache`, `repository-cache`) stay the same.
> 
> **`actions/checkout`** is bumped from `v5.0.0` to `v6.0.2`, and **`actions/upload-artifact`** from `v5` to `v6` for the coverage report upload—both are major-version upgrades (typically Node/runtime updates on the action side).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed04d9511d42ca486485122c9c8918346668c432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->