### PR TITLE
ci: speed up CI — fix Bazel cache + fold race into one coverage pass

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,12 @@ build --stamp
 build --workspace_status_command=./ci/status.sh
 run --stamp
 run --workspace_status_command=./ci/status.sh
+
+# Enable the Go race detector with --config=race.
+build:race --@rules_go//go/config:race
+
+# Shared CI flags, applied to test/build/coverage via --config=ci so CI
+# behavior lives here instead of being inlined in the ci/*.sh scripts.
+build:ci --verbose_failures
+build:ci --action_env=CI=true
+test:ci --test_output=errors

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,14 +41,17 @@ jobs:
           # Cache downloaded external repositories / module dependencies.
           repository-cache: true
 
-      - name: Test
-        run: make test
+      - name: Lint
+        run: make lint
+
+      # Runs every test with the Go race detector while collecting coverage,
+      # so this single pass is both the test gate and the coverage report
+      # (no separate race-test pass).
+      - name: Test & coverage
+        run: make coverage
 
       - name: Build
         run: make build
-
-      - name: Coverage
-        run: make coverage
 
       - name: Publish code cov
         uses: actions/upload-artifact@v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      # Checkout MUST come first: setup-bazel derives its cache keys by hashing
+      # repo files (MODULE.bazel.lock, BUILD files, *.bzl). Without the sources
+      # present, the key is static and GitHub never saves an updated cache, so
+      # the Bazel disk cache freezes after the first run. Checkout also lets
+      # setup-go read the Go version straight from go.mod.
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.3
+          # Track the Go version pinned in go.mod (kept in sync with
+          # MODULE.bazel's go_sdk.download) instead of hardcoding it here.
+          go-version-file: go.mod
 
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
@@ -21,14 +31,15 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
-          # Avoid downloading Bazel every time.
+          # The Bazel version itself is pinned by .bazelversion (9.1.0) and
+          # resolved by bazelisk; this only caches the downloaded Bazel binary.
           bazelisk-cache: true
-          # Store build cache per workflow.
+          # Cache the Bazel disk cache (compiled action outputs). Keyed by the
+          # workflow plus a hash of the build files, so it invalidates when
+          # dependencies or BUILD files change and is refreshed each run.
           disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows.
+          # Cache downloaded external repositories / module dependencies.
           repository-cache: true
-
-      - uses: actions/checkout@v6.0.2
 
       - name: Test
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean gazelle help link fmt test coverage upgrade _godeps push deploy tidy unlink _tidy
+.PHONY: build clean gazelle help link fmt lint test coverage upgrade _godeps push deploy tidy unlink _tidy
 .DEFAULT_GOAL = help
 VERSION ?= $(shell openssl rand -base64 8 |md5 |head -c8)
 
@@ -13,6 +13,9 @@ deploy: ## Deploy services to k8s
 
 fmt: ## Run build-fmt
 	bash ci/build-fmt.sh
+
+lint: ## Run format/lint checks (gofmt + buildifier)
+	bash ci/lint.sh
 
 gazelle: ## Run gazelle update
 	bazel run //:gazelle -- update

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -26,8 +26,13 @@ coverWithGo() {
 }
 
 
-coverWithBazel() {  
-  bazel coverage --combined_report=lcov //...
+coverWithBazel() {
+  # This pass doubles as the CI test gate: it runs every test with the Go race
+  # detector (--config=race) while collecting coverage, so there is no separate
+  # race-test pass. Race is scoped to test targets (via query) because the OCI
+  # image targets transition to a cgo-disabled platform that race rejects.
+  bazel coverage --config=ci --config=race --combined_report=lcov \
+    $(bazel query 'kind(".*_test rule", //...)')
   genhtml --branch-coverage --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
 
   echo "Coverage completed."

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Lint gate: verify Go source and Bazel BUILD files are correctly formatted.
+# Extracted from ci/test.sh so CI can run the fast format checks as their own
+# step, independent of the (heavier) Bazel test/coverage pass.
+
+env GO111MODULE=on
+BUILDIFIER_VERSION="5.4.0"
+
+which buildifier >/dev/null
+if [ $? -ne 0 ]; then
+  go install github.com/bazelbuild/buildtools/buildifier@$BUILDIFIER_VERSION
+fi
+
+set -eux
+
+gocount=$(git ls-files | grep '.go$' | grep -v 'bindata_assetfs.go$' | grep -v 'bindatafs.go$' | grep -v 'pb.go$' | grep -v 'bindata.go$' | grep -v 'pb.gw.go$' | xargs gofmt -e -l -s | wc -l)
+if [ "$gocount" -gt 0 ]; then
+  echo "Some Go files are not formatted. Check your formatting!"
+  exit 1
+fi
+
+buildcount=$(buildifier -mode=check $(find . -type f \( -iname BUILD -or -iname BUILD.bazel \) | grep -v node_modules | grep -v vendor) | wc -l)
+if [ "$buildcount" -gt 0 ]; then
+    echo "Some BUILD files are not formatted. Run make fmt"
+    exit 1
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,33 +1,13 @@
 #!/bin/bash
-# This script is used to test the repo
+# Run the lint gate, then execute all Bazel tests with the Go race detector.
+#
+# Race is scoped to test targets (via query) rather than //...: the OCI image
+# targets transition to a cgo-disabled static platform, which is incompatible
+# with race instrumentation.
 
-env GO111MODULE=on
-BUILDIFIER_VERSION="5.4.0"
+set -eu
 
-which buildifier >/dev/null
-if [ $? -ne 0 ]; then
-  go install github.com/bazelbuild/buildtools/buildifier@$BUILDIFIER_VERSION
-fi
+bash ci/lint.sh
 
-set -eux
-
-gocount=$(git ls-files | grep '.go$' | grep -v 'bindata_assetfs.go$' | grep -v 'bindatafs.go$' | grep -v 'pb.go$' | grep -v 'bindata.go$' | grep -v 'pb.gw.go$' | xargs gofmt -e -l -s | wc -l)
-if [ "$gocount" -gt 0 ]; then
-  echo "Some Go files are not formatted. Check your formatting!"
-  exit 1
-fi
-
-buildcount=$(buildifier -mode=check $(find . -type f \( -iname BUILD -or -iname BUILD.bazel \) | grep -v node_modules | grep -v vendor) | wc -l)
-if [ "$buildcount" -gt 0 ]; then
-    echo "Some BUILD files are not formatted. Run make fmt"
-    exit 1
-fi
-
-bazeltests=$(bazel query 'kind(".*_test rule", //...)')
-for i in ${bazeltests[@]}; do
-    echo "testing $i"
-    bazel test --@rules_go//go/config:race \
-  --verbose_failures \
-  --test_output=errors \
-  --action_env=CI=true "${i}"
-done
+set -x
+bazel test --config=ci --config=race $(bazel query 'kind(".*_test rule", //...)')


### PR DESCRIPTION
Two related CI speedups. Both verified locally (`make lint`, `make test`, `make build` pass; `bazel coverage --config=ci --config=race` produces the combined lcov report).

## 1. Fix the Bazel disk cache (the big one)

`setup-bazel` caching was configured but silently dead: **`actions/checkout` ran *after* `setup-bazel`**, so the cache key (a hash of `MODULE.bazel.lock` / `BUILD` / `*.bzl`) was computed against an empty tree. A static key means GitHub never saves a fresh cache after the first run — the disk cache **froze at the first run** and every later run rebuilt all the drift from that baseline.

- **Checkout is now the first step** → `setup-bazel` hashes the real lockfiles, so the cache key self-invalidates and refreshes each run.
- **`setup-go` → `go-version-file: go.mod`** instead of a hardcoded `1.25.3` (was triple-maintained across go.mod / MODULE.bazel / workflow).
- Bazel version stays pinned by `.bazelversion` (9.1.0) via bazelisk. No manual `actions/cache` — `setup-bazel`'s built-in caching is the right mechanism.

## 2. Fold the race detector into the coverage pass

CI compiled+ran the test suite **twice** — once race-instrumented (`make test`) and again coverage-instrumented (`make coverage`) — plus a third default build. `bazel coverage` already runs the tests, so:

- **`.bazelrc`**: add `--config=race` (Go race detector) and a shared `--config=ci` (the `verbose_failures` / `action_env=CI=true` / `test_output=errors` flags previously inlined in the scripts).
- **`ci/coverage.sh`**: `bazel coverage --config=ci --config=race` — one pass = tests + race + coverage. Scoped to **test targets** (not `//...`) because the OCI image targets transition to a cgo-disabled static platform that race instrumentation rejects.
- **`ci/lint.sh`** (new): extracts the gofmt + buildifier gate out of `ci/test.sh` so CI keeps the lint checks without re-running tests.
- **`ci/test.sh`**: lint gate + a single race test pass (de-looped from the per-target loop) — for local `make test`.
- **Workflow**: `Lint → Test & coverage → Build` (the standalone race-test step is gone).

### CI step flow
`Checkout → Set up Go → Setup LCOV → Setup Bazel → Lint → Test & coverage → Build → Publish code cov`

### Net effect
One instrumented test pass instead of two, on a disk cache that actually persists. The first run on `main` after merge is still cold (it populates the cache); warm runs are the win.

> Config choice (per discussion): there is **no single config for everything** — `build_all` must stay default (shippable, un-instrumented), coverage must be instrumented, race only applies to test targets. So we fold race *into* coverage rather than unify configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)