### PR TITLE
oci: push multi-arch image index (linux/amd64 + arm64)

### DIFF
--- a/cmd/helloworld-client/BUILD.bazel
+++ b/cmd/helloworld-client/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 # This client links the lean (non-gateway) proto variant. helloworld_go_proto and
@@ -49,6 +49,30 @@ platform_transition_filegroup(
     }),
 )
 
+# Build the app image for each target platform and assemble them into a
+# multi-arch image index (manifest list). Pushing the index means one tag
+# resolves correctly on both linux/amd64 and linux/arm64 nodes, instead of the
+# single host-arch image that :transitioned_image produces.
+platform_transition_filegroup(
+    name = "image_linux_amd64",
+    srcs = [":image"],
+    target_platform = "@rules_go//go/toolchain:linux_amd64",
+)
+
+platform_transition_filegroup(
+    name = "image_linux_arm64",
+    srcs = [":image"],
+    target_platform = "@rules_go//go/toolchain:linux_arm64",
+)
+
+oci_image_index(
+    name = "image_index",
+    images = [
+        ":image_linux_amd64",
+        ":image_linux_arm64",
+    ],
+)
+
 ## $ bazel run //oci_go_image:load
 # $ docker run --rm gcr.io/example:latest
 #   string(
@@ -80,7 +104,7 @@ expand_template(
 
 oci_push(
     name = "push",
-    image = ":transitioned_image",
+    image = ":image_index",
     remote_tags = ":stamped",
     repository = "ghcr.io/esurdam/go-grpc-bazel-example/cmd/helloworld-client",
     visibility = ["//visibility:public"],

--- a/services/helloworld/BUILD.bazel
+++ b/services/helloworld/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_bazel_lib//lib:testing.bzl", "assert_archive_contains")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 # Gateway service: link the gateway proto variant. helloworld_go_proto and
@@ -77,6 +77,30 @@ platform_transition_filegroup(
     }),
 )
 
+# Build the app image for each target platform and assemble them into a
+# multi-arch image index (manifest list). Pushing the index means one tag
+# resolves correctly on both linux/amd64 and linux/arm64 nodes, instead of the
+# single host-arch image that :transitioned_image produces.
+platform_transition_filegroup(
+    name = "image_linux_amd64",
+    srcs = [":image"],
+    target_platform = "@rules_go//go/toolchain:linux_amd64",
+)
+
+platform_transition_filegroup(
+    name = "image_linux_arm64",
+    srcs = [":image"],
+    target_platform = "@rules_go//go/toolchain:linux_arm64",
+)
+
+oci_image_index(
+    name = "image_index",
+    images = [
+        ":image_linux_amd64",
+        ":image_linux_arm64",
+    ],
+)
+
 # $ bazel run //oci_go_image:load
 # $ docker run --rm gcr.io/example:latest
 #   string(
@@ -108,7 +132,7 @@ expand_template(
 
 oci_push(
     name = "push",
-    image = ":transitioned_image",
+    image = ":image_index",
     remote_tags = ":stamped",
     repository = "ghcr.io/esurdam/go-grpc-bazel-example/services/helloworld",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Tier-2 of the OCI modernization. Independent of #170 (Tier 1) — touches the same two BUILD files but on non-overlapping lines.

## Problem

`oci_push` published `:transitioned_image`, whose `platform_transition_filegroup` selects on the **builder's** CPU:

```python
target_platform = select({
    "@platforms//cpu:arm64":  "@rules_go//go/toolchain:linux_arm64",
    "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
})
```

So the pushed tag was a **single-arch** image — linux/arm64 when built on an Apple-silicon dev box, linux/amd64 from a CI runner. It only runs on nodes matching whoever built it.

## Change (both `services/helloworld` and `cmd/helloworld-client`)

- Add explicit per-platform images `image_linux_amd64` / `image_linux_arm64`.
- Assemble them into an **`oci_image_index`** (manifest list) and point `oci_push` at `:image_index`.
- `oci_load` still uses `:transitioned_image` (host arch) for local `bazel run :load` — a single-arch image is what you actually run locally.

Used the **stable** `images = [...]` form with pre-transitioned images (the rule's own documented example); deliberately avoided `oci_image_index`'s `platforms` attribute, which is flagged "highly EXPERIMENTAL, not subject to SemVer" in rules_oci 2.3.0.

## Verification

- `bazel build //...` ✅ green (cross-compiles Go for both arches).
- Inspected the generated index — it's a real manifest list:
  ```
  mediaType: application/vnd.oci.image.index.v1+json
   - linux/amd64 sha256:74799386bf3fa71dd...
   - linux/arm64 sha256:63e62ab1297750119...
  ```
- `ci/push-service.sh` / `ci/deploy.sh` need no changes — the `oci_push` interface is unchanged, and the index is always multi-arch regardless of `--cpu`.

## Remaining
- **Tier 3**: replace the `sed`-templated, non-applying `ci/deploy.sh` with Kustomize/GitOps + deploy by digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/publish-only Bazel OCI wiring with no runtime or application code changes; push tags become manifest lists that should work on mixed-arch clusters.
> 
> **Overview**
> **OCI pushes now publish a multi-arch manifest list** for `services/helloworld` and `cmd/helloworld-client` instead of a single image whose arch followed the builder’s CPU.
> 
> Each `BUILD.bazel` adds explicit `linux/amd64` and `linux/arm64` `platform_transition_filegroup` targets, combines them with **`oci_image_index`**, and points **`oci_push`** at `:image_index`. **`oci_load`** still uses `:transitioned_image` so local `bazel run :load` stays host-arch only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad848c6150e44c27fe06757b0999637028410015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->