### PR TITLE
oci: deploy by digest via Kustomize (Tier 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage.html
 coverage.txt
 ssl/
 genhtml/
+
+# Generated at deploy time by ci/deploy.sh (digest-pinned Kustomize overlay)
+deploy/*/overlays/

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,41 +1,56 @@
 #!/bin/bash
-# This script is used to deploy services to k8s
-# It will:
-# 1. Query all push rules
-# 2. For each push rule, it will:
-#    a. Check if the yaml file exists
-#    b. Run the push rule to get the image tag 
-#    c. Get the version from the stamped file
-#    d. Replace the image tag and version in the yaml file
-#    e. Apply the yaml file to k8s
+# Deploy the helloworld service to Kubernetes.
+#
+# Pushes the multi-arch image index, derives its immutable @sha256 digest from
+# the built artifact, generates a Kustomize overlay pinned to that digest, and
+# applies it. Deploying by digest (not a mutable tag) makes rollouts reproducible.
 
-env GO111MODULE=on
+set -euo pipefail
 
-set -e
-set -u
-set -x
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
 
-TOOLCHAIN="@rules_go//go/toolchain:linux_amd64" # TODO: Make this configurable
-CPU="k8"  # k8 is the default cpu for linux
+PUSH_TARGET="//services/helloworld:push"
+IMAGE_INDEX="//services/helloworld:image_index"
+IMAGE_REPO="ghcr.io/esurdam/go-grpc-bazel-example/services/helloworld"
+OVERLAY_DIR="deploy/helloworld/overlays/live"
 
-process_service() {
-  local i=$1
-  local root="${i/\/\//}" # remove the leading //
-  local core="${root/:push/}" # remove the trailing :push
-  # check if yaml exists
-  if [ ! -f "ci/${core}.yaml" ]; then
-    echo "yaml file not found: ci/${core}.yaml"
-    return 0
-  fi
-  # local IMAGE_TAG=$(bazel run --platforms=$TOOLCHAIN --cpu=$CPU "$i")
-  local IMAGE_TAG=$(bazel run --cpu=$CPU "$i")
-  local VERSION=$(cat "$(bazel cquery --output=files "${i/:push/:stamped}")")
-  # replace the image tag and version in the yaml file
-  local template=$(cat "ci/${core}.yaml" | sed "s#{{IMAGE_TAG}}#$IMAGE_TAG#g" | sed "s/{{VERSION}}/$VERSION/g")
-  echo "$template"
-}
+command -v kubectl >/dev/null || { echo "deploy: kubectl not found on PATH" >&2; exit 1; }
+command -v jq >/dev/null || { echo "deploy: jq not found on PATH" >&2; exit 1; }
 
-# Queries for all push rules and deploys them
-for i in $(bazel query 'kind(".push rule", //...)'); do
-  process_service "$i"
-done
+# 1. Build the multi-arch index and derive its digest from the OCI layout.
+#    This digest is content-addressed, so it is identical to what gets pushed.
+bazel build "$IMAGE_INDEX"
+INDEX_DIR="$(bazel cquery --output=files "$IMAGE_INDEX" 2>/dev/null | head -1)"
+DIGEST="$(jq -r '.manifests[0].digest' "$INDEX_DIR/index.json")"
+if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+  echo "deploy: could not read image digest from $INDEX_DIR/index.json" >&2
+  exit 1
+fi
+
+# 2. Push the multi-arch index (SHA-tagged via :stamped).
+bazel run "$PUSH_TARGET"
+
+# 3. Generate the (gitignored) overlay pinned to the digest, with the git commit
+#    recorded as an annotation for traceability.
+GIT_SHA="$(git rev-parse --short HEAD)"
+mkdir -p "$OVERLAY_DIR"
+cat > "$OVERLAY_DIR/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: ${IMAGE_REPO}
+    digest: ${DIGEST}
+
+commonAnnotations:
+  app.kubernetes.io/version: "${GIT_SHA}"
+EOF
+
+# 4. Render as a self-check (fails fast if the overlay is invalid), then apply.
+echo "deploy: rendering ${IMAGE_REPO}@${DIGEST} (commit ${GIT_SHA})"
+kubectl kustomize "$OVERLAY_DIR"
+kubectl apply -k "$OVERLAY_DIR"

--- a/ci/services/BUILD
+++ b/ci/services/BUILD
@@ -1,5 +1,0 @@
-package(default_visibility = ["//visibility:public"])
-
-exports_files([
-    "helloworld.yaml",
-])

--- a/deploy/helloworld/base/deployment.yaml
+++ b/deploy/helloworld/base/deployment.yaml
@@ -23,10 +23,14 @@ spec:
         - name: dockerconfigjson-github-com
       containers:
         - name: helloworld-container
-          image: {{IMAGE_TAG}}
+          # Image name only; `make deploy` pins this to an immutable @sha256
+          # digest via the generated Kustomize overlay (deploy/helloworld/overlays/live).
+          image: ghcr.io/esurdam/go-grpc-bazel-example/services/helloworld:latest
           ports:
             - containerPort: 443
-          imagePullPolicy: Always
+          # Safe to skip re-pulling: we deploy by immutable digest, so the
+          # reference can never point at different content.
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               memory: "32Mi"
@@ -44,25 +48,7 @@ spec:
               path: /swagger.json
               port: 443
           env:
-            - name: DEPLOY
-              value: {{VERSION}}
             - name: ENV
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: helloworld-service
-  labels:
-    app: helloworld
-  annotations:
-    prometheus.io/port: '10824'
-    prometheus.io/scrape: 'true'
-spec:
-  ports:
-    - port: 443
-      name: mux
-  selector:
-    app: helloworld

--- a/deploy/helloworld/base/kustomization.yaml
+++ b/deploy/helloworld/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base manifests for the helloworld service. The image is pinned to an
+# immutable @sha256 digest at deploy time by the generated overlay in
+# ../overlays/live (see ci/deploy.sh); this base is valid on its own.
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/deploy/helloworld/base/service.yaml
+++ b/deploy/helloworld/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: helloworld-service
+  labels:
+    app: helloworld
+  annotations:
+    prometheus.io/port: '10824'
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+    - port: 443
+      name: mux
+  selector:
+    app: helloworld


### PR DESCRIPTION
Final tier of the OCI→k8s modernization (Tier 1 #170 digest pin + SHA tags; Tier 2 #171 multi-arch index). Makes `make deploy` a real, reproducible deploy using the modern Kustomize + deploy-by-digest pattern — no external CD infra.

## The bug this fixes

`ci/deploy.sh` `sed`-substituted `{{IMAGE_TAG}}`/`{{VERSION}}` into `ci/services/helloworld.yaml` and then only **`echo`d** the result — it never ran `kubectl apply`. So "deploy to k8s" deployed nothing.

## What changed

- **`deploy/helloworld/base/`** — Kustomize base (`deployment.yaml` + `service.yaml` + `kustomization.yaml`), moved from `ci/services/helloworld.yaml`.
- **`ci/deploy.sh`** rewritten (`set -euo pipefail`):
  1. `bazel build //services/helloworld:image_index` and derive its immutable digest from the OCI layout (`jq -r '.manifests[0].digest' index.json`) — content-addressed, so identical to what gets pushed.
  2. `bazel run //services/helloworld:push` (multi-arch, SHA-tagged).
  3. Generate a **gitignored** overlay `deploy/helloworld/overlays/live/` that pins `images: [{name, digest}]` and records the git SHA as `app.kubernetes.io/version`.
  4. `kubectl kustomize …` (self-check render) → `kubectl apply -k …`.
- **Deploy-by-digest fallout**: `imagePullPolicy: Always → IfNotPresent` (digest is immutable); `{{IMAGE_TAG}}`/`{{VERSION}}` sed placeholders gone; `DEPLOY` env replaced by the version annotation.
- Removed `ci/services/{helloworld.yaml,BUILD}` (the `exports_files` was unused — nothing in Bazel referenced the manifest).
- `.gitignore`: `deploy/*/overlays/`.

Uses kubectl's **embedded** Kustomize — no standalone `kustomize` CLI needed.

## Verification (no live cluster)

`kubectl kustomize deploy/helloworld/overlays/live` renders the Deployment with:
```
image: ghcr.io/esurdam/go-grpc-bazel-example/services/helloworld@sha256:7f3eaf66c31fa6f9f3ad803d97aebc0e609dd48438646fcc718e6afa090a2055
imagePullPolicy: IfNotPresent
metadata.annotations.app.kubernetes.io/version: 183a556
```
`bazel build //...` green; no Bazel target referenced the moved manifest.

## Out of scope (natural follow-ups)
GitOps (Argo/Flux), multi-env overlays, cosign signing / SBOM, wiring deploy into CI on merge/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy path and cluster rollout behavior (first real `kubectl apply`); digest pinning reduces tag drift but mis-read digest or overlay errors could deploy wrong or broken manifests.
> 
> **Overview**
> **`make deploy` now actually applies Kubernetes manifests** instead of only printing sed-substituted YAML. `ci/deploy.sh` is narrowed to helloworld: it builds the multi-arch OCI index, reads the immutable digest from the local layout, pushes via Bazel, writes a **gitignored** `deploy/helloworld/overlays/live` Kustomize overlay that pins `images` by digest and sets `app.kubernetes.io/version` to the short git SHA, then runs `kubectl kustomize` and **`kubectl apply -k`**.
> 
> Manifests move from `ci/services/helloworld.yaml` into **`deploy/helloworld/base/`** (Deployment + Service + `kustomization.yaml`). The base uses a static image name with `:latest`; deploy-time overlay rewrites to `@sha256:…`. **`imagePullPolicy`** becomes `IfNotPresent`; **`DEPLOY` / `{{VERSION}}` placeholders** are dropped in favor of the version annotation. **`ci/services/`** and its Bazel `exports_files` are removed; **`.gitignore`** excludes generated overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27101364525a445da74fe575e1817cf83dd07c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->