### PR TITLE
chore: meet minimum reqs for awesome go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,11 +50,20 @@ jobs:
       - name: Test & coverage
         run: make coverage
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.lcov
+          flags: unittests
+          name: bazel-coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Build
         run: make build
 
-      - name: Publish code cov
+      - name: Publish coverage HTML
         uses: actions/upload-artifact@v7
         with:
-          name: code covarege report
+          name: coverage-report
           path: genhtml/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ bazel-*
 
 coverage.html
 coverage.txt
+coverage.lcov
+coverage.out
 ssl/
 genhtml/
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Evan Surdam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # go-grpc-bazel-example
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/esurdam/go-grpc-bazel-example.svg)](https://pkg.go.dev/github.com/esurdam/go-grpc-bazel-example)
+[![Go Report Card](https://goreportcard.com/badge/github.com/esurdam/go-grpc-bazel-example)](https://goreportcard.com/report/github.com/esurdam/go-grpc-bazel-example)
+[![codecov](https://codecov.io/gh/esurdam/go-grpc-bazel-example/branch/main/graph/badge.svg)](https://codecov.io/gh/esurdam/go-grpc-bazel-example)
 [![test](https://github.com/esurdam/go-grpc-bazel-example/actions/workflows/go.yml/badge.svg)](https://github.com/esurdam/go-grpc-bazel-example/actions/workflows/go.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/esurdam/go-grpc-bazel-example/blob/main/LICENSE)
 
 ## Project Overview
 
@@ -328,6 +332,12 @@ make deploy
 See [ci/deploy.sh](ci/deploy.sh) and [deploy/helloworld/base](deploy/helloworld/base)
 
 ## Useful Links
+
+**Quality reports**
+
+- [pkg.go.dev](https://pkg.go.dev/github.com/esurdam/go-grpc-bazel-example)
+- [Go Report Card](https://goreportcard.com/report/github.com/esurdam/go-grpc-bazel-example)
+- [Codecov](https://app.codecov.io/gh/esurdam/go-grpc-bazel-example)
 
 **GRPC**
 

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -33,7 +33,12 @@ coverWithBazel() {
   # image targets transition to a cgo-disabled platform that race rejects.
   bazel coverage --config=ci --config=race --combined_report=lcov \
     $(bazel query 'kind(".*_test rule", //...)')
-  genhtml --branch-coverage --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
+
+  local report
+  report="$(bazel info output_path)/_coverage/_coverage_report.dat"
+  # Stable path for Codecov / other coverage services.
+  cp "${report}" coverage.lcov
+  genhtml --branch-coverage --output genhtml "${report}"
 
   echo "Coverage completed."
   echo "Open genhtml/index.html to view result."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation, license, and CI reporting only; no runtime or application logic changes.
> 
> **Overview**
> Adds **project hygiene** for awesome-go-style listings: an **MIT LICENSE**, README badges (pkg.go.dev, Go Report Card, Codecov, MIT), and a **Quality reports** links section.
> 
> **CI coverage** now copies Bazel’s combined LCOV report to a stable `coverage.lcov` in `ci/coverage.sh`, uploads it to Codecov via `codecov/codecov-action@v5` (non-blocking on upload errors), and renames the HTML artifact to `coverage-report` (fixes the old typo). **`.gitignore`** ignores `coverage.lcov` and `coverage.out`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719a90b06966ee65023baf2fd0c69b8269ed4d4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->