### PR TITLE
feat: add scalar api docs UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,4 +79,6 @@ See the scaffold pattern in `README.md` for full details.
 ## Swagger / OpenAPI
 
 - Expose Swagger JSON at `/swagger.json` for each service.
+- Expose interactive Scalar docs at `/docs/` via `pkg/openapi.Mount` (CDN-backed; air-gapped envs should embed assets).
+- Prefer `openapi_naming_strategy=simple` and explicit `openapiv2_schema` / field options so model names stay readable.
 - Use the `gateway_grpc_library` and `gateway_openapiv2_compile` Bazel rules for OpenAPI generation.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Follow these steps to get the example service running locally:
      ```
 
 6. **View Swagger/OpenAPI Docs**
-   - Open [https://localhost:4443/swagger.json](https://localhost:4443/swagger.json) in your browser.
+   - Interactive UI: [https://localhost:4443/docs/](https://localhost:4443/docs/)
+   - Raw spec: [https://localhost:4443/swagger.json](https://localhost:4443/swagger.json)
 
 _For more details, see the sections below._
 
@@ -204,7 +205,7 @@ Then we use cURL to send HTTP requests
 curl -X POST -k https://localhost:4443/v1/greeter -d '{"name": "TestName"}'
 ```
 
-You can view the swagger at [https://localhost:4443/swagger.json](https://localhost:4443/swagger.json)
+You can view the interactive docs at [https://localhost:4443/docs/](https://localhost:4443/docs/) or the raw swagger at [https://localhost:4443/swagger.json](https://localhost:4443/swagger.json)
 
 Or use the client:
 With the server running, you can test command line tools from `cmd`.
@@ -284,7 +285,15 @@ View the `genrule` in [BUILD.bazel](services/helloworld/BUILD.bazel)
 var Data []byte
 ```
 
-Services can then expose the `swagger.json` file directly.
+Services can then expose the `swagger.json` file and an interactive docs UI:
+
+```go
+openapi.Mount(mux, Data, "Helloworld API")
+```
+
+`pkg/openapi` serves Scalar API Reference at `/docs/` (CDN-backed, pinned jsDelivr
+build) pointed at your embedded spec. `/docs` redirects to `/docs/`. The CDN keeps
+binaries small; air-gapped deployments should vendor Scalar assets instead.
 
 ## Deployment
 

--- a/pb/helloworld/BUILD.bazel
+++ b/pb/helloworld/BUILD.bazel
@@ -14,7 +14,10 @@ proto_library(
     name = "helloworld_proto",
     srcs = ["helloworld.proto"],
     visibility = ["//visibility:public"],
-    deps = ["@googleapis//google/api:annotations_proto"],
+    deps = [
+        "@googleapis//google/api:annotations_proto",
+        "@grpc_ecosystem_grpc_gateway//protoc-gen-openapiv2/options:options_proto",
+    ],
 )
 
 # This is used for packages that do not require gateway; like cmd/client
@@ -24,7 +27,10 @@ go_proto_library(
     importpath = "github.com/esurdam/go-grpc-bazel-example/pb/helloworld",
     proto = ":helloworld_proto",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_google_genproto_googleapis_api//annotations"],
+    deps = [
+        "@grpc_ecosystem_grpc_gateway//protoc-gen-openapiv2/options:options_go_proto",
+        "@org_golang_google_genproto_googleapis_api//annotations",
+    ],
 )
 
 # This is used for packages that require gateway; like services/helloworld
@@ -34,13 +40,18 @@ gateway_grpc_library(
     protos = [":helloworld_proto"],
     visibility = ["//visibility:public"],
     deps = [
+        "@grpc_ecosystem_grpc_gateway//protoc-gen-openapiv2/options:options_go_proto",
         "@org_golang_google_genproto_googleapis_api//annotations",
     ],
 )
 
-# This outputs a swagger.json file that can be served by the gateway
+# This outputs a swagger.json file that can be served by the gateway.
+# simple naming yields HelloRequest/HelloReply instead of helloworldHelloRequest.
 gateway_openapiv2_compile(
     name = "helloworld_openapi_swagger",
+    options = {
+        "*": ["openapi_naming_strategy=simple"],
+    },
     protos = [":helloworld_proto"],
     visibility = ["//visibility:public"],
 )

--- a/pb/helloworld/helloworld.proto
+++ b/pb/helloworld/helloworld.proto
@@ -5,24 +5,64 @@ option go_package = "github.com/esurdam/go-grpc-bazel-example/pb/helloworld";
 package helloworld;
 
 import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
 
-// The greeting service definition.
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Helloworld API";
+    version: "1.0";
+    description: "A simple greeter service exposing gRPC and REST.";
+  };
+  schemes: HTTPS;
+  consumes: "application/json";
+  produces: "application/json";
+};
+
+// Greeter greets callers over gRPC and REST.
 service Greeter {
-    // Sends a greeting
-    rpc SayHello (HelloRequest) returns (HelloReply) {
-        option (google.api.http) = {
-          post: "/v1/greeter"
-          body: "*"
-        };
-    }
+  // SayHello returns a greeting for the given name.
+  rpc SayHello(HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      post: "/v1/greeter"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Say hello";
+      description: "Returns a greeting for the provided name.";
+      tags: "Greeter";
+    };
+  }
 }
 
-// The request message containing the user's name.
+// HelloRequest is the input to SayHello.
 message HelloRequest {
-    string name = 1;
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    json_schema: {
+      title: "HelloRequest";
+      description: "Request body for SayHello.";
+      required: ["name"];
+    }
+  };
+
+  string name = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    title: "name";
+    description: "Name of the person to greet.";
+    example: "\"World\"";
+  }];
 }
 
-// The response message containing the greetings
+// HelloReply is the response from SayHello.
 message HelloReply {
-    string message = 1;
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    json_schema: {
+      title: "HelloReply";
+      description: "Greeting response from SayHello.";
+    }
+  };
+
+  string message = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    title: "message";
+    description: "The greeting message.";
+    example: "\"Hello World\"";
+  }];
 }

--- a/pkg/openapi/BUILD.bazel
+++ b/pkg/openapi/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "openapi",
+    srcs = ["docs.go"],
+    importpath = "github.com/esurdam/go-grpc-bazel-example/pkg/openapi",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "openapi_test",
+    srcs = ["docs_test.go"],
+    deps = [":openapi"],
+)

--- a/pkg/openapi/docs.go
+++ b/pkg/openapi/docs.go
@@ -1,0 +1,85 @@
+// Package openapi serves interactive OpenAPI documentation for API servers.
+//
+// The docs UI is Scalar API Reference loaded from a pinned jsDelivr CDN URL.
+// That keeps service binaries small and is acceptable for local/dev and typical
+// cluster environments with egress. Air-gapped deployments that need a fully
+// self-contained UI should vendor/embed the Scalar assets instead.
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+)
+
+// Pin Scalar for reproducible docs UI; bump intentionally when upgrading.
+const scalarCDN = "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.43.5"
+
+const scalarHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Title}}</title>
+  <style>
+    body { margin: 0; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="{{.CDN}}" crossorigin="anonymous"></script>
+  <script>
+    Scalar.createApiReference("#app", {
+      url: {{.SpecURL}},
+      hideClientButton: true,
+    });
+  </script>
+</body>
+</html>`
+
+var docsTmpl = template.Must(template.New("scalar").Parse(scalarHTML))
+
+// DocsHandler returns an http.Handler that serves Scalar API Reference
+// configured to load the OpenAPI/Swagger spec from specURL (e.g. "/swagger.json").
+func DocsHandler(specURL, title string) http.Handler {
+	if title == "" {
+		title = "API documentation"
+	}
+	if specURL == "" {
+		specURL = "/swagger.json"
+	}
+	specJSON, err := json.Marshal(specURL)
+	if err != nil {
+		// Impossible for a string, but keep the handler usable.
+		specJSON = []byte(`"/swagger.json"`)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := docsTmpl.Execute(w, map[string]any{
+			"Title":   title,
+			"CDN":     scalarCDN,
+			"SpecURL": template.JS(specJSON),
+		}); err != nil {
+			http.Error(w, fmt.Sprintf("render docs: %v", err), http.StatusInternalServerError)
+		}
+	})
+}
+
+// SpecHandler returns an http.Handler that serves the OpenAPI/Swagger JSON
+// document with the correct Content-Type.
+func SpecHandler(spec []byte) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(spec)
+	})
+}
+
+// Mount registers the OpenAPI spec at /swagger.json and Scalar docs at /docs/.
+// Requests to /docs (no trailing slash) redirect to /docs/.
+func Mount(mux *http.ServeMux, spec []byte, title string) {
+	docs := DocsHandler("/swagger.json", title)
+	mux.Handle("/swagger.json", SpecHandler(spec))
+	mux.Handle("/docs", http.RedirectHandler("/docs/", http.StatusFound))
+	mux.Handle("/docs/", docs)
+}

--- a/pkg/openapi/docs_test.go
+++ b/pkg/openapi/docs_test.go
@@ -1,0 +1,162 @@
+package openapi_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/esurdam/go-grpc-bazel-example/pkg/openapi"
+)
+
+func TestDocsHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		specURL string
+		title   string
+		wantIn  []string
+		wantNot []string
+	}{
+		{
+			name:    "defaults",
+			specURL: "",
+			title:   "",
+			wantIn: []string{
+				"API documentation",
+				`url: "/swagger.json"`,
+				"@scalar/api-reference@",
+				"Scalar.createApiReference",
+			},
+		},
+		{
+			name:    "custom title and spec",
+			specURL: "/v1/openapi.json",
+			title:   "Greeter API",
+			wantIn: []string{
+				"Greeter API",
+				`url: "/v1/openapi.json"`,
+				"Scalar.createApiReference",
+			},
+		},
+		{
+			name:    "escapes hostile title and spec URL",
+			specURL: `"</script><script>alert(1)</script>`,
+			title:   `<script>alert("xss")</script>`,
+			wantIn: []string{
+				`&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;`,
+				`url: "\"\u003c/script\u003e\u003cscript\u003ealert(1)\u003c/script\u003e"`,
+			},
+			wantNot: []string{
+				`<script>alert("xss")</script>`,
+				`url: "</script><script>alert(1)</script>"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/docs/", nil)
+			rr := httptest.NewRecorder()
+			openapi.DocsHandler(tt.specURL, tt.title).ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+			}
+			ct := rr.Header().Get("Content-Type")
+			if !strings.HasPrefix(ct, "text/html") {
+				t.Fatalf("Content-Type = %q, want text/html", ct)
+			}
+			body := rr.Body.String()
+			for _, want := range tt.wantIn {
+				if !strings.Contains(body, want) {
+					t.Errorf("body missing %q\nbody:\n%s", want, body)
+				}
+			}
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(body, notWant) {
+					t.Errorf("body unexpectedly contains %q", notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestSpecHandler(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`{"openapi":"3.0.0","info":{"title":"t","version":"1"}}`)
+	req := httptest.NewRequest(http.MethodGet, "/swagger.json", nil)
+	rr := httptest.NewRecorder()
+	openapi.SpecHandler(spec).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	if got := rr.Body.String(); got != string(spec) {
+		t.Fatalf("body = %q, want %q", got, spec)
+	}
+}
+
+func TestMountRoutes(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`{"swagger":"2.0","info":{"title":"Helloworld API","version":"1.0"}}`)
+	mux := http.NewServeMux()
+	openapi.Mount(mux, spec, "Helloworld API")
+
+	t.Run("docs redirects to trailing slash", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusFound {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusFound)
+		}
+		if got := rr.Header().Get("Location"); got != "/docs/" {
+			t.Fatalf("Location = %q, want /docs/", got)
+		}
+	})
+
+	t.Run("docs slash serves UI", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/docs/", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, "Helloworld API") {
+			t.Fatalf("docs body missing title")
+		}
+		if !strings.Contains(body, `url: "/swagger.json"`) {
+			t.Fatalf("docs body missing spec url")
+		}
+	})
+
+	t.Run("swagger json", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/swagger.json", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if got := rr.Body.String(); got != string(spec) {
+			t.Fatalf("body = %q, want %q", got, spec)
+		}
+	})
+}

--- a/services/helloworld/BUILD.bazel
+++ b/services/helloworld/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
     deps = [
         "//pb/helloworld:helloworld_gateway_proto",  # keep
         "//pkg/helloworld/server",
+        "//pkg/openapi",
         "@com_github_philip_bui_grpc_zerolog//:grpc-zerolog",
         "@grpc_ecosystem_grpc_gateway//runtime",
         "@org_golang_google_grpc//:grpc",

--- a/services/helloworld/main.go
+++ b/services/helloworld/main.go
@@ -18,6 +18,7 @@ import (
 
 	pb "github.com/esurdam/go-grpc-bazel-example/pb/helloworld"
 	"github.com/esurdam/go-grpc-bazel-example/pkg/helloworld/server"
+	"github.com/esurdam/go-grpc-bazel-example/pkg/openapi"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	zerolog "github.com/philip-bui/grpc-zerolog"
 	"google.golang.org/grpc"
@@ -102,11 +103,9 @@ func main() {
 		log.Fatalln("failed to register gateway:", err)
 	}
 
-	// Handle swagger
+	// Handle OpenAPI spec + interactive docs UI
 	mux := http.NewServeMux()
-	mux.HandleFunc("/swagger.json", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(Data)
-	})
+	openapi.Mount(mux, Data, "Helloworld API")
 	mux.Handle("/", gwmux)
 
 	// Handle server


### PR DESCRIPTION
- Add reusable `pkg/openapi` helpers (`Mount` / `DocsHandler` / `SpecHandler`) that serve Scalar API Reference from a pinned jsDelivr CDN.
- Wire helloworld to expose interactive docs at `/docs/` (with `/docs` → `/docs/` redirect) alongside existing `/swagger.json`.
- Enrich helloworld OpenAPI output with swagger info, operation/schema/field metadata, and `openapi_naming_strategy=simple` so models render as `HelloRequest` / `HelloReply`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new static HTTP routes and CDN-backed docs UI without changing API handlers; XSS-sensitive HTML is covered by tests and JSON/templating for the spec URL.
> 
> **Overview**
> Adds reusable **`pkg/openapi`** helpers so services can serve embedded OpenAPI at **`/swagger.json`** and **Scalar API Reference** at **`/docs/`** (with **`/docs`** redirect), using a pinned jsDelivr CDN build to keep binaries small.
> 
> **Helloworld** replaces the hand-written swagger handler with **`openapi.Mount`**, and the greeter proto/Bazel OpenAPI pipeline gains **openapiv2** metadata (API info, operation tags/summaries, schema/field descriptions) plus **`openapi_naming_strategy=simple`** so generated models show as **`HelloRequest`** / **`HelloReply`**. AGENTS.md and README document the new docs URLs and recommended OpenAPI conventions.
> 
> Tests cover route wiring, JSON spec serving, and HTML escaping for hostile titles/spec URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c0e60e30562bb3af4da2e1f035f2cd62681d6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->