### PR TITLE
fix: grpc ops hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Monorepo — all microservices, protobufs, and shared code live in a single repo
 - `pkg/` — Go implementations of proto services.
 - `services/` — Entrypoints for deployable microservices.
 - `cmd/` — Standalone command-line tools.
-- `ci/` — CI/CD scripts and Kubernetes manifests.
+- `ci/` — CI/CD scripts.
+- `deploy/` — Kubernetes manifests (Kustomize bases/overlays).
 - `tools/` — Tool versioning and helper scripts.
 - `ssl/` — Local self-signed certificates (never commit private keys).
 
@@ -18,7 +19,7 @@ Monorepo — all microservices, protobufs, and shared code live in a single repo
 
 - **Build all services**: `make build` or `bazel build :build_all`
 - **Run all tests**: `make test` or `bazel test //...`
-- **Run single test**: `bazel test --features race --verbose_failures --test_output=errors //pkg/path:target_test`
+- **Run single test**: `bazel test --config=race --verbose_failures --test_output=errors //pkg/path:target_test`
 - **Format code**: `make fmt`
 - **Generate protos**: `make link`
 - **Update BUILD files**: `make gazelle`
@@ -44,7 +45,7 @@ Each new service must have:
 - Proto definition in `pb/<service>/<service>.proto`
 - Implementation in `pkg/<service>/server/server.go`
 - Entrypoint in `services/<service>/main.go`
-- Kubernetes manifest in `ci/services/<service>.yaml`
+- Kubernetes manifests in `deploy/<service>/base/`
 - Aggregation in the root `BUILD` file
 
 See the scaffold pattern in `README.md` for full details.
@@ -54,14 +55,14 @@ See the scaffold pattern in `README.md` for full details.
 - All code must have tests. Use table-driven tests with descriptive names.
 - Write comprehensive unit tests for all implementations.
 - Run `make test` before submitting changes.
-- Run an individual package test with `bazel test --features race --verbose_failures --test_output=errors //pkg/path:target_test`.
+- Run an individual package test with `bazel test --config=race --verbose_failures --test_output=errors //pkg/path:target_test`.
 
 ## Code Style
 
 - Follow Go standard formatting with `gofmt -s`.
 - Organize imports with `goimports`.
 - Format Bazel files with `buildifier`.
-- Error handling: return simple error objects (`errors.New()`) for validation.
+- Error handling: return typed gRPC errors (`status.Error(codes.InvalidArgument, ...)`) for validation.
 - Package naming: use domain-oriented packages under `pkg/`.
 - Proto implementation: shared services in `pkg/`, service-specific in `services/{name}/pkg/`.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,11 @@ See [ci/push-service.sh](ci/push-service.sh)
 Since [rules_docker](https://github.com/bazelbuild/rules_docker) has been deprecated, there is no `k8s_deploy` rule. Instead `make deploy` pushes the image, derives its immutable `@sha256` digest, renders a [Kustomize](https://kustomize.io/) overlay pinned to that digest, and applies it with `kubectl apply -k`. Deploying by digest (rather than a moving tag) keeps rollouts reproducible.
 
 Manifests live in `deploy/<service>/base`; the digest-pinned overlay is generated at deploy time. Requires `kubectl` and `jq`.
+
+Create a TLS secret before the first deploy (the Deployment mounts `helloworld-tls` at `/etc/tls` and probes `HTTPS /healthz`):
+
 ```bash
+kubectl create secret tls helloworld-tls --cert=ssl/cert.pem --key=ssl/key.pem
 make deploy
 ```
 

--- a/cmd/helloworld-client/main.go
+++ b/cmd/helloworld-client/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"log"
+	"net"
 	"os"
 	"time"
 
@@ -38,10 +39,15 @@ func main() {
 		}
 	}
 
+	serverName := *serverAddr
+	if host, _, err := net.SplitHostPort(*serverAddr); err == nil {
+		serverName = host
+	}
 	dcreds := credentials.NewTLS(&tls.Config{
-		ServerName:         *serverAddr,
+		ServerName:         serverName,
 		RootCAs:            rootCAs,
 		InsecureSkipVerify: *insecure,
+		MinVersion:         tls.VersionTLS12,
 	})
 	conn, err := grpc.NewClient(*serverAddr, grpc.WithTransportCredentials(dcreds))
 	if err != nil {

--- a/deploy/helloworld/base/deployment.yaml
+++ b/deploy/helloworld/base/deployment.yaml
@@ -14,10 +14,6 @@ spec:
     metadata:
       labels:
         app: helloworld
-      annotations:
-        # prometheus annotations by default
-        prometheus.io/port: '10824'
-        prometheus.io/scrape: 'true'
     spec:
       imagePullSecrets:
         - name: dockerconfigjson-github-com
@@ -27,7 +23,8 @@ spec:
           # digest via the generated Kustomize overlay (deploy/helloworld/overlays/live).
           image: ghcr.io/esurdam/go-grpc-bazel-example/services/helloworld:latest
           ports:
-            - containerPort: 443
+            - name: mux
+              containerPort: 443
           # Safe to skip re-pulling: we deploy by immutable digest, so the
           # reference can never point at different content.
           imagePullPolicy: IfNotPresent
@@ -38,17 +35,39 @@ spec:
             limits:
               memory: "64Mi"
               cpu: "100m"
-          # should contain a healthcheck path & port; excluded for brevity in this repo
           livenessProbe:
             httpGet:
-              path: /swagger.json
-              port: 443
+              path: /healthz
+              port: mux
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /swagger.json
-              port: 443
+              path: /healthz
+              port: mux
+              scheme: HTTPS
+            initialDelaySeconds: 2
+            periodSeconds: 5
           env:
             - name: ENV
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_PATH
+              value: /etc/tls/tls.crt
+            - name: SSL_KEY_PATH
+              value: /etc/tls/tls.key
+            - name: SSL_CA_CERT_PATH
+              value: /etc/tls/tls.crt
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+      volumes:
+        # Create before deploy, e.g.:
+        #   kubectl create secret tls helloworld-tls \
+        #     --cert=ssl/cert.pem --key=ssl/key.pem
+        - name: tls
+          secret:
+            secretName: helloworld-tls

--- a/deploy/helloworld/base/service.yaml
+++ b/deploy/helloworld/base/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-service
   labels:
     app: helloworld
-  annotations:
-    prometheus.io/port: '10824'
-    prometheus.io/scrape: 'true'
 spec:
   ports:
     - port: 443
       name: mux
+      targetPort: mux
   selector:
     app: helloworld

--- a/pkg/helloworld/server/BUILD.bazel
+++ b/pkg/helloworld/server/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pb/helloworld:helloworld_gateway_proto",  # keep
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 
@@ -20,5 +22,7 @@ go_test(
     deps = [
         ":server",
         "//pb/helloworld:helloworld_gateway_proto",  # keep
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/pkg/helloworld/server/server.go
+++ b/pkg/helloworld/server/server.go
@@ -2,10 +2,11 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	pb "github.com/esurdam/go-grpc-bazel-example/pb/helloworld"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Server implements pb.GreeterServer
@@ -16,7 +17,7 @@ type Server struct {
 // SayHello implements pb.GreeterServer
 func (s *Server) SayHello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
 	if req.Name == "" {
-		return nil, errors.New("name is required")
+		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
 	return &pb.HelloReply{Message: fmt.Sprintf("Hello %s!", req.Name)}, nil
 }

--- a/pkg/helloworld/server/server_test.go
+++ b/pkg/helloworld/server/server_test.go
@@ -7,6 +7,8 @@ import (
 
 	pb "github.com/esurdam/go-grpc-bazel-example/pb/helloworld"
 	"github.com/esurdam/go-grpc-bazel-example/pkg/helloworld/server"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestServer_SayHello(t *testing.T) {
@@ -15,47 +17,36 @@ func TestServer_SayHello(t *testing.T) {
 		req *pb.HelloRequest
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *pb.HelloReply
-		wantErr bool
+		name     string
+		args     args
+		want     *pb.HelloReply
+		wantErr  bool
+		wantCode codes.Code
 	}{
 		{
-			name: "TestServer_SayHello",
+			name: "greets by name",
 			args: args{
 				ctx: context.Background(),
-				req: &pb.HelloRequest{
-					Name: "TestName",
-				},
+				req: &pb.HelloRequest{Name: "TestName"},
 			},
-			want: &pb.HelloReply{
-				Message: "Hello TestName!",
-			},
-			wantErr: false,
+			want: &pb.HelloReply{Message: "Hello TestName!"},
 		},
 		{
-			name: "TestServer_SayHello2",
+			name: "greets user",
 			args: args{
 				ctx: context.Background(),
-				req: &pb.HelloRequest{
-					Name: "user",
-				},
+				req: &pb.HelloRequest{Name: "user"},
 			},
-			want: &pb.HelloReply{
-				Message: "Hello user!",
-			},
-			wantErr: false,
+			want: &pb.HelloReply{Message: "Hello user!"},
 		},
 		{
-			name: "TestServer_SayHelloErr",
+			name: "empty name is invalid argument",
 			args: args{
 				ctx: context.Background(),
-				req: &pb.HelloRequest{
-					Name: "",
-				},
+				req: &pb.HelloRequest{Name: ""},
 			},
-			want:    nil,
-			wantErr: true,
+			wantErr:  true,
+			wantCode: codes.InvalidArgument,
 		},
 	}
 	for _, tt := range tests {
@@ -63,7 +54,12 @@ func TestServer_SayHello(t *testing.T) {
 			s := &server.Server{}
 			got, err := s.SayHello(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SayHello() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("SayHello() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if status.Code(err) != tt.wantCode {
+					t.Fatalf("SayHello() status = %v, want %v", status.Code(err), tt.wantCode)
+				}
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/services/helloworld/BUILD.bazel
+++ b/services/helloworld/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -34,6 +34,22 @@ go_library(
         "@grpc_ecosystem_grpc_gateway//runtime",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//health",
+        "@org_golang_google_grpc//health/grpc_health_v1",
+    ],
+)
+
+go_test(
+    name = "helloworld_test",
+    srcs = ["main_test.go"],
+    embed = [":helloworld_lib"],
+    deps = [
+        "//pb/helloworld:helloworld_gateway_proto",  # keep
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )
 

--- a/services/helloworld/BUILD.bazel
+++ b/services/helloworld/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//health/grpc_health_v1",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/protojson",
     ],

--- a/services/helloworld/main.go
+++ b/services/helloworld/main.go
@@ -35,6 +35,15 @@ var (
 	insecure  = flag.Bool("insecure", false, "enable insecure tls skip verify for grpc-gateway")
 )
 
+type serverConfig struct {
+	httpPort int
+	cert     string
+	key      string
+	ca       string
+	insecure bool
+	swagger  []byte
+}
+
 func grpcHandlerFunc(grpcServer *grpc.Server, httpServer http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
@@ -126,33 +135,35 @@ func newMux(ctx context.Context, dialAddr string, rootCAs *x509.CertPool, skipVe
 	return grpcHandlerFunc(grpcServer, mux), grpcServer, nil
 }
 
-func main() {
-	flag.Parse()
-	applyEnvFallbacks(sslCert, sslKey, sslCACert)
-
-	pair, err := tls.LoadX509KeyPair(*sslCert, *sslKey)
+// run starts the TLS multiplexed server and blocks until ctx is canceled,
+// then drains in-flight requests via http.Server.Shutdown.
+func run(ctx context.Context, cfg serverConfig) error {
+	pair, err := tls.LoadX509KeyPair(cfg.cert, cfg.key)
 	if err != nil {
-		log.Fatalf("unable to load ssl cert or key -- required: %v\n", err)
+		return fmt.Errorf("unable to load ssl cert or key -- required: %w", err)
 	}
 
-	rootCAs, err := loadRootCAs(*sslCACert)
+	rootCAs, err := loadRootCAs(cfg.ca)
 	if err != nil {
-		log.Fatalf("unable to load ca certs: %v\n", err)
+		return fmt.Errorf("unable to load ca certs: %w", err)
 	}
 
-	addr := fmt.Sprintf("localhost:%d", *httpPort)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Gateway dial lifecycle is independent of the shutdown signal so
+	// http.Server.Shutdown can drain in-flight REST requests first.
+	muxCtx, muxCancel := context.WithCancel(context.Background())
+	defer muxCancel()
 
-	handler, _, err := newMux(ctx, addr, rootCAs, *insecure, Data)
+	addr := fmt.Sprintf("localhost:%d", cfg.httpPort)
+	handler, _, err := newMux(muxCtx, addr, rootCAs, cfg.insecure, cfg.swagger)
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
-	conn, err := net.Listen("tcp", fmt.Sprintf(":%d", *httpPort))
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.httpPort))
 	if err != nil {
-		log.Fatalf("unable to listen on tcp port %d, %v\n", *httpPort, err)
+		return fmt.Errorf("unable to listen on tcp port %d: %w", cfg.httpPort, err)
 	}
+
 	gwServer := &http.Server{
 		Addr:              addr,
 		Handler:           handler,
@@ -164,26 +175,56 @@ func main() {
 			MinVersion: tls.VersionTLS12,
 		},
 	}
+
+	errCh := make(chan error, 1)
 	go func() {
 		log.Printf("serving at https://%s\n", addr)
-		if err := gwServer.Serve(tls.NewListener(conn, gwServer.TLSConfig)); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("listen: %s\n", err)
+		if err := gwServer.Serve(tls.NewListener(ln, gwServer.TLSConfig)); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+			return
 		}
+		errCh <- nil
 	}()
 
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
-	log.Println("shutting down server...")
-
-	ctxClos, cancelClose := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancelClose()
-	// Drain active HTTP/gRPC handlers first. Canceling the gateway dial
-	// context earlier would close the backend conn mid-flight; defer cancel()
-	// runs after Shutdown returns.
-	if err := gwServer.Shutdown(ctxClos); err != nil {
-		log.Fatal("server forced to shutdown:", err)
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		if err != nil {
+			_ = ln.Close()
+			return err
+		}
 	}
 
+	shutdownCtx, cancelClose := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelClose()
+	if err := gwServer.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("server forced to shutdown: %w", err)
+	}
+	return <-errCh
+}
+
+var notifyContext = signal.NotifyContext
+
+func main() {
+	if err := mainErr(Data); err != nil {
+		log.Fatal(err)
+	}
 	log.Println("server exiting")
+}
+
+func mainErr(swagger []byte) error {
+	flag.Parse()
+	applyEnvFallbacks(sslCert, sslKey, sslCACert)
+
+	ctx, stop := notifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	return run(ctx, serverConfig{
+		httpPort: *httpPort,
+		cert:     *sslCert,
+		key:      *sslKey,
+		ca:       *sslCACert,
+		insecure: *insecure,
+		swagger:  swagger,
+	})
 }

--- a/services/helloworld/main.go
+++ b/services/helloworld/main.go
@@ -23,6 +23,8 @@ import (
 	zerolog "github.com/philip-bui/grpc-zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var (
@@ -43,82 +45,123 @@ func grpcHandlerFunc(grpcServer *grpc.Server, httpServer http.Handler) http.Hand
 	})
 }
 
-func main() {
-	flag.Parse()
-
-	// Source cert info in production
-	switch {
-	case *sslCert == "":
-		*sslCert = os.Getenv("SSL_CERT_PATH")
-	case *sslKey == "":
-		*sslKey = os.Getenv("SSL_KEY_PATH")
-	case *sslCACert == "":
-		*sslCACert = os.Getenv("SSL_CA_CERT_PATH")
+func applyEnvFallbacks(cert, key, ca *string) {
+	if *cert == "" {
+		*cert = os.Getenv("SSL_CERT_PATH")
+	}
+	if *key == "" {
+		*key = os.Getenv("SSL_KEY_PATH")
+	}
+	if *ca == "" {
+		*ca = os.Getenv("SSL_CA_CERT_PATH")
 	}
 	// In this example, the generated cert contains the CA.
-	// In a production environment, the CA Cert should be seperate
-	if *sslCACert == "" {
-		*sslCACert = *sslCert
+	// In a production environment, the CA cert should be separate.
+	if *ca == "" {
+		*ca = *cert
 	}
+}
+
+func loadRootCAs(caPath string) (*x509.CertPool, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("system cert pool: %w", err)
+	}
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if caPath == "" {
+		return rootCAs, nil
+	}
+	certPEMBlock, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ca cert %q: %w", caPath, err)
+	}
+	if !rootCAs.AppendCertsFromPEM(certPEMBlock) {
+		return nil, fmt.Errorf("append ca certs from PEM: bad certs")
+	}
+	return rootCAs, nil
+}
+
+func tlsServerName(hostPort string) string {
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return hostPort
+	}
+	return host
+}
+
+// newMux builds the HTTP/gRPC multiplexed handler. TLS is terminated by
+// http.Server; do not attach grpc.Creds when using ServeHTTP.
+func newMux(ctx context.Context, dialAddr string, rootCAs *x509.CertPool, skipVerify bool, swagger []byte) (http.Handler, *grpc.Server, error) {
+	grpcServer := grpc.NewServer(zerolog.UnaryInterceptor())
+	pb.RegisterGreeterServer(grpcServer, &server.Server{})
+
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pb.Greeter_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+
+	dcreds := credentials.NewTLS(&tls.Config{
+		ServerName:         tlsServerName(dialAddr),
+		RootCAs:            rootCAs,
+		InsecureSkipVerify: skipVerify,
+		MinVersion:         tls.VersionTLS12,
+	})
+	gwmux := runtime.NewServeMux()
+	if err := pb.RegisterGreeterHandlerFromEndpoint(ctx, gwmux, dialAddr, []grpc.DialOption{
+		grpc.WithTransportCredentials(dcreds),
+	}); err != nil {
+		return nil, nil, fmt.Errorf("register gateway: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	openapi.Mount(mux, swagger, "Helloworld API")
+	mux.Handle("/", gwmux)
+
+	return grpcHandlerFunc(grpcServer, mux), grpcServer, nil
+}
+
+func main() {
+	flag.Parse()
+	applyEnvFallbacks(sslCert, sslKey, sslCACert)
 
 	pair, err := tls.LoadX509KeyPair(*sslCert, *sslKey)
 	if err != nil {
 		log.Fatalf("unable to load ssl cert or key -- required: %v\n", err)
 	}
 
-	rootCAs, _ := x509.SystemCertPool()
-	if rootCAs == nil {
-		rootCAs = x509.NewCertPool()
+	rootCAs, err := loadRootCAs(*sslCACert)
+	if err != nil {
+		log.Fatalf("unable to load ca certs: %v\n", err)
 	}
-	if *sslCACert != "" {
-		certPEMBlock, _ := os.ReadFile(*sslCACert)
-		ok := rootCAs.AppendCertsFromPEM([]byte(certPEMBlock))
-		if !ok {
-			log.Fatal("unable to append certs from PEM: bad certs")
-		}
-	}
+
 	addr := fmt.Sprintf("localhost:%d", *httpPort)
-
-	opts := []grpc.ServerOption{
-		zerolog.UnaryInterceptor(),
-		grpc.Creds(credentials.NewClientTLSFromCert(rootCAs, addr)),
-	}
-	grpcServer := grpc.NewServer(opts...)
-	pb.RegisterGreeterServer(grpcServer, &server.Server{})
-
-	// Register Greeter
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dcreds := credentials.NewTLS(&tls.Config{
-		ServerName:         addr,
-		RootCAs:            rootCAs,
-		InsecureSkipVerify: *insecure,
-	})
-	dopts := []grpc.DialOption{
-		grpc.WithTransportCredentials(dcreds),
-	}
-	gwmux := runtime.NewServeMux()
-	if err := pb.RegisterGreeterHandlerFromEndpoint(ctx, gwmux, addr, dopts); err != nil {
-		log.Fatalln("failed to register gateway:", err)
+	handler, _, err := newMux(ctx, addr, rootCAs, *insecure, Data)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	// Handle OpenAPI spec + interactive docs UI
-	mux := http.NewServeMux()
-	openapi.Mount(mux, Data, "Helloworld API")
-	mux.Handle("/", gwmux)
-
-	// Handle server
 	conn, err := net.Listen("tcp", fmt.Sprintf(":%d", *httpPort))
 	if err != nil {
 		log.Fatalf("unable to listen on tcp port %d, %v\n", *httpPort, err)
 	}
 	gwServer := &http.Server{
-		Addr:    addr,
-		Handler: grpcHandlerFunc(grpcServer, mux),
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{pair},
-			NextProtos:   []string{"h2"},
+			// Advertise both so kubelet HTTPS probes (HTTP/1.1) and gRPC (h2) work.
+			NextProtos: []string{"h2", "http/1.1"},
+			MinVersion: tls.VersionTLS12,
 		},
 	}
 	go func() {
@@ -128,20 +171,14 @@ func main() {
 		}
 	}()
 
-	// Wait for interrupt signal to gracefully shutdown the server with
-	// a timeout of 5 seconds.
 	quit := make(chan os.Signal, 1)
-	// kill (no param) default send syscall.SIGTERM
-	// kill -2 is syscall.SIGINT
-	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	log.Println("shutting down server...")
 
-	// The context is used to inform the server it has 5 seconds to finish
-	// the request it is currently handling
 	ctxClos, cancelClose := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelClose()
+	cancel() // stop gateway dial context
 	if err := gwServer.Shutdown(ctxClos); err != nil {
 		log.Fatal("server forced to shutdown:", err)
 	}

--- a/services/helloworld/main.go
+++ b/services/helloworld/main.go
@@ -178,7 +178,9 @@ func main() {
 
 	ctxClos, cancelClose := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelClose()
-	cancel() // stop gateway dial context
+	// Drain active HTTP/gRPC handlers first. Canceling the gateway dial
+	// context earlier would close the backend conn mid-flight; defer cancel()
+	// runs after Shutdown returns.
 	if err := gwServer.Shutdown(ctxClos); err != nil {
 		log.Fatal("server forced to shutdown:", err)
 	}

--- a/services/helloworld/main_test.go
+++ b/services/helloworld/main_test.go
@@ -232,7 +232,7 @@ func TestMuxTLSGRPCAndREST(t *testing.T) {
 				MinVersion: tls.VersionTLS12,
 				NextProtos: []string{"http/1.1"},
 			},
-			TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
+			TLSNextProto:      map[string]func(string, *tls.Conn) http.RoundTripper{},
 			ForceAttemptHTTP2: false,
 		}}
 		resp, err := client.Get("https://" + addr + "/healthz")

--- a/services/helloworld/main_test.go
+++ b/services/helloworld/main_test.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/esurdam/go-grpc-bazel-example/pb/helloworld"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestTLSServerName(t *testing.T) {
+	if got := tlsServerName("localhost:4443"); got != "localhost" {
+		t.Fatalf("tlsServerName() = %q, want localhost", got)
+	}
+	if got := tlsServerName("localhost"); got != "localhost" {
+		t.Fatalf("tlsServerName() = %q, want localhost", got)
+	}
+}
+
+func TestApplyEnvFallbacks(t *testing.T) {
+	t.Setenv("SSL_CERT_PATH", "/env/cert.pem")
+	t.Setenv("SSL_KEY_PATH", "/env/key.pem")
+	t.Setenv("SSL_CA_CERT_PATH", "/env/ca.pem")
+
+	cert, key, ca := "", "", ""
+	applyEnvFallbacks(&cert, &key, &ca)
+	if cert != "/env/cert.pem" || key != "/env/key.pem" || ca != "/env/ca.pem" {
+		t.Fatalf("applyEnvFallbacks() = (%q, %q, %q)", cert, key, ca)
+	}
+}
+
+func TestMuxTLSGRPCAndREST(t *testing.T) {
+	certPEM, keyPEM := mustTestCert(t)
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	addr := ln.Addr().String()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	swagger := []byte(`{"swagger":"2.0","info":{"title":"test","version":"0"},"paths":{}}`)
+	handler, _, err := newMux(ctx, addr, rootCAs, false, swagger)
+	if err != nil {
+		t.Fatalf("newMux: %v", err)
+	}
+
+	srv := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{pair},
+			NextProtos:   []string{"h2", "http/1.1"},
+			MinVersion:   tls.VersionTLS12,
+		},
+	}
+	go func() {
+		_ = srv.Serve(tls.NewListener(ln, srv.TLSConfig))
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+
+	tlsConfig := &tls.Config{
+		RootCAs:    rootCAs,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	}
+
+	waitHealthy(t, "https://"+addr+"/healthz", tlsConfig)
+
+	t.Run("healthz", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+		resp, err := client.Get("https://" + addr + "/healthz")
+		if err != nil {
+			t.Fatalf("GET /healthz: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "ok" {
+			t.Fatalf("body = %q", body)
+		}
+	})
+
+	t.Run("swagger", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+		resp, err := client.Get("https://" + addr + "/swagger.json")
+		if err != nil {
+			t.Fatalf("GET /swagger.json: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d", resp.StatusCode)
+		}
+		var doc map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			t.Fatalf("decode swagger: %v", err)
+		}
+		if doc["swagger"] != "2.0" {
+			t.Fatalf("swagger = %v", doc["swagger"])
+		}
+	})
+
+	t.Run("rest sayhello", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+		resp, err := client.Post(
+			"https://"+addr+"/v1/greeter",
+			"application/json",
+			strings.NewReader(`{"name":"Test"}`),
+		)
+		if err != nil {
+			t.Fatalf("POST rest: %v", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d body = %s", resp.StatusCode, body)
+		}
+		var reply pb.HelloReply
+		if err := protojson.Unmarshal(body, &reply); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if reply.Message != "Hello Test!" {
+			t.Fatalf("message = %q", reply.Message)
+		}
+	})
+
+	t.Run("rest validation", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+		resp, err := client.Post(
+			"https://"+addr+"/v1/greeter",
+			"application/json",
+			strings.NewReader(`{"name":""}`),
+		)
+		if err != nil {
+			t.Fatalf("POST rest: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d body = %s, want 400", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("grpc sayhello", func(t *testing.T) {
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		defer conn.Close()
+		cli := pb.NewGreeterClient(conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		reply, err := cli.SayHello(ctx, &pb.HelloRequest{Name: "gRPC"})
+		if err != nil {
+			t.Fatalf("SayHello: %v", err)
+		}
+		if reply.Message != "Hello gRPC!" {
+			t.Fatalf("message = %q", reply.Message)
+		}
+	})
+
+	t.Run("grpc validation", func(t *testing.T) {
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		defer conn.Close()
+		cli := pb.NewGreeterClient(conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = cli.SayHello(ctx, &pb.HelloRequest{Name: ""})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("status = %v, want InvalidArgument", status.Code(err))
+		}
+	})
+}
+
+func waitHealthy(t *testing.T, url string, tlsConfig *tls.Config) {
+	t.Helper()
+	client := &http.Client{
+		Timeout:   time.Second,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server not healthy: %v", err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func mustTestCert(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		t.Fatal(fmt.Errorf("empty pem"))
+	}
+	return certPEM, keyPEM
+}

--- a/services/helloworld/main_test.go
+++ b/services/helloworld/main_test.go
@@ -15,6 +15,9 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -37,15 +41,118 @@ func TestTLSServerName(t *testing.T) {
 }
 
 func TestApplyEnvFallbacks(t *testing.T) {
-	t.Setenv("SSL_CERT_PATH", "/env/cert.pem")
-	t.Setenv("SSL_KEY_PATH", "/env/key.pem")
-	t.Setenv("SSL_CA_CERT_PATH", "/env/ca.pem")
+	t.Run("fills all from env", func(t *testing.T) {
+		t.Setenv("SSL_CERT_PATH", "/env/cert.pem")
+		t.Setenv("SSL_KEY_PATH", "/env/key.pem")
+		t.Setenv("SSL_CA_CERT_PATH", "/env/ca.pem")
 
-	cert, key, ca := "", "", ""
-	applyEnvFallbacks(&cert, &key, &ca)
-	if cert != "/env/cert.pem" || key != "/env/key.pem" || ca != "/env/ca.pem" {
-		t.Fatalf("applyEnvFallbacks() = (%q, %q, %q)", cert, key, ca)
+		cert, key, ca := "", "", ""
+		applyEnvFallbacks(&cert, &key, &ca)
+		if cert != "/env/cert.pem" || key != "/env/key.pem" || ca != "/env/ca.pem" {
+			t.Fatalf("applyEnvFallbacks() = (%q, %q, %q)", cert, key, ca)
+		}
+	})
+
+	t.Run("flags win over env", func(t *testing.T) {
+		t.Setenv("SSL_CERT_PATH", "/env/cert.pem")
+		t.Setenv("SSL_KEY_PATH", "/env/key.pem")
+		t.Setenv("SSL_CA_CERT_PATH", "/env/ca.pem")
+
+		cert, key, ca := "/flag/cert.pem", "/flag/key.pem", "/flag/ca.pem"
+		applyEnvFallbacks(&cert, &key, &ca)
+		if cert != "/flag/cert.pem" || key != "/flag/key.pem" || ca != "/flag/ca.pem" {
+			t.Fatalf("applyEnvFallbacks() = (%q, %q, %q)", cert, key, ca)
+		}
+	})
+
+	t.Run("ca falls back to cert", func(t *testing.T) {
+		t.Setenv("SSL_CERT_PATH", "")
+		t.Setenv("SSL_KEY_PATH", "")
+		t.Setenv("SSL_CA_CERT_PATH", "")
+
+		cert, key, ca := "/only/cert.pem", "/only/key.pem", ""
+		applyEnvFallbacks(&cert, &key, &ca)
+		if ca != "/only/cert.pem" {
+			t.Fatalf("ca = %q, want cert path", ca)
+		}
+	})
+}
+
+func TestLoadRootCAs(t *testing.T) {
+	certPEM, _ := mustTestCert(t)
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
+
+	t.Run("empty path", func(t *testing.T) {
+		pool, err := loadRootCAs("")
+		if err != nil {
+			t.Fatalf("loadRootCAs: %v", err)
+		}
+		if pool == nil {
+			t.Fatal("expected non-nil pool")
+		}
+	})
+
+	t.Run("valid ca file", func(t *testing.T) {
+		pool, err := loadRootCAs(caPath)
+		if err != nil {
+			t.Fatalf("loadRootCAs: %v", err)
+		}
+		if pool == nil {
+			t.Fatal("expected non-nil pool")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := loadRootCAs(filepath.Join(dir, "missing.pem")); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("bad pem", func(t *testing.T) {
+		bad := filepath.Join(dir, "bad.pem")
+		if err := os.WriteFile(bad, []byte("not-a-cert"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := loadRootCAs(bad); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestGRPCHandlerFunc(t *testing.T) {
+	httpHits := 0
+	grpcSrv := grpc.NewServer()
+	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		httpHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := grpcHandlerFunc(grpcSrv, httpHandler)
+
+	t.Run("http path", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		req.ProtoMajor = 1
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if httpHits != 1 {
+			t.Fatalf("httpHits = %d", httpHits)
+		}
+	})
+
+	t.Run("non-grpc h2 still http", func(t *testing.T) {
+		before := httpHits
+		req := httptest.NewRequest(http.MethodGet, "/docs/", nil)
+		req.ProtoMajor = 2
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if httpHits != before+1 {
+			t.Fatalf("httpHits = %d", httpHits)
+		}
+	})
 }
 
 func TestMuxTLSGRPCAndREST(t *testing.T) {
@@ -90,7 +197,6 @@ func TestMuxTLSGRPCAndREST(t *testing.T) {
 	t.Cleanup(func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
-		cancel()
 		_ = srv.Shutdown(shutdownCtx)
 	})
 
@@ -118,6 +224,30 @@ func TestMuxTLSGRPCAndREST(t *testing.T) {
 		}
 	})
 
+	t.Run("healthz http1", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    rootCAs,
+				ServerName: "localhost",
+				MinVersion: tls.VersionTLS12,
+				NextProtos: []string{"http/1.1"},
+			},
+			TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
+			ForceAttemptHTTP2: false,
+		}}
+		resp, err := client.Get("https://" + addr + "/healthz")
+		if err != nil {
+			t.Fatalf("GET /healthz: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.ProtoMajor != 1 {
+			t.Fatalf("proto = %s, want HTTP/1.x", resp.Proto)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d", resp.StatusCode)
+		}
+	})
+
 	t.Run("swagger", func(t *testing.T) {
 		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
 		resp, err := client.Get("https://" + addr + "/swagger.json")
@@ -134,6 +264,18 @@ func TestMuxTLSGRPCAndREST(t *testing.T) {
 		}
 		if doc["swagger"] != "2.0" {
 			t.Fatalf("swagger = %v", doc["swagger"])
+		}
+	})
+
+	t.Run("docs", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+		resp, err := client.Get("https://" + addr + "/docs/")
+		if err != nil {
+			t.Fatalf("GET /docs/: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d", resp.StatusCode)
 		}
 	})
 
@@ -210,6 +352,292 @@ func TestMuxTLSGRPCAndREST(t *testing.T) {
 			t.Fatalf("status = %v, want InvalidArgument", status.Code(err))
 		}
 	})
+
+	t.Run("grpc health", func(t *testing.T) {
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		defer conn.Close()
+		cli := healthpb.NewHealthClient(conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		for _, service := range []string{"", pb.Greeter_ServiceDesc.ServiceName} {
+			resp, err := cli.Check(ctx, &healthpb.HealthCheckRequest{Service: service})
+			if err != nil {
+				t.Fatalf("Check(%q): %v", service, err)
+			}
+			if resp.Status != healthpb.HealthCheckResponse_SERVING {
+				t.Fatalf("Check(%q) status = %v", service, resp.Status)
+			}
+		}
+	})
+}
+
+func TestRunStartsAndShutsDown(t *testing.T) {
+	certPEM, keyPEM := mustTestCert(t)
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, serverConfig{
+			httpPort: port,
+			cert:     certPath,
+			key:      keyPath,
+			ca:       certPath,
+			swagger:  []byte(`{"swagger":"2.0","info":{"title":"test","version":"0"},"paths":{}}`),
+		})
+	}()
+
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	tlsConfig := &tls.Config{
+		RootCAs:    rootCAs,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	}
+	waitHealthy(t, fmt.Sprintf("https://127.0.0.1:%d/healthz", port), tlsConfig)
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+	resp, err := client.Post(
+		fmt.Sprintf("https://127.0.0.1:%d/v1/greeter", port),
+		"application/json",
+		strings.NewReader(`{"name":"Run"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body = %s", resp.StatusCode, body)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not shut down")
+	}
+}
+
+func TestMainErr(t *testing.T) {
+	certPEM, keyPEM := mustTestCert(t)
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	origNotify := notifyContext
+	t.Cleanup(func() { notifyContext = origNotify })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	notifyContext = func(parent context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+		return ctx, cancel
+	}
+
+	origCert, origKey, origCA, origPort := *sslCert, *sslKey, *sslCACert, *httpPort
+	t.Cleanup(func() {
+		*sslCert, *sslKey, *sslCACert, *httpPort = origCert, origKey, origCA, origPort
+	})
+	*sslCert, *sslKey, *sslCACert, *httpPort = certPath, keyPath, certPath, port
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mainErr([]byte(`{"swagger":"2.0","info":{"title":"test","version":"0"},"paths":{}}`))
+	}()
+
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	waitHealthy(t, fmt.Sprintf("https://127.0.0.1:%d/healthz", port), &tls.Config{
+		RootCAs:    rootCAs,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("mainErr: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("mainErr did not return")
+	}
+}
+
+func TestRunMissingCert(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := run(ctx, serverConfig{
+		httpPort: 0,
+		cert:     filepath.Join(t.TempDir(), "missing.pem"),
+		key:      filepath.Join(t.TempDir(), "missing-key.pem"),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunBadCA(t *testing.T) {
+	certPEM, keyPEM := mustTestCert(t)
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "bad-ca.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+	if err := os.WriteFile(caPath, []byte("not-a-cert"), 0o600); err != nil {
+		t.Fatalf("WriteFile ca: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := run(ctx, serverConfig{
+		httpPort: 0,
+		cert:     certPath,
+		key:      keyPath,
+		ca:       caPath,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunPortInUse(t *testing.T) {
+	certPEM, keyPEM := mustTestCert(t)
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+
+	// Bind the same wildcard form run() uses (":port") so the port is taken.
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = run(ctx, serverConfig{
+		httpPort: port,
+		cert:     certPath,
+		key:      keyPath,
+		ca:       certPath,
+		swagger:  []byte(`{}`),
+	})
+	if err == nil {
+		t.Fatal("expected listen error")
+	}
+}
+
+func TestNewMuxCanceledContext(t *testing.T) {
+	certPEM, _ := mustTestCert(t)
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := newMux(ctx, "127.0.0.1:1", rootCAs, true, []byte(`{}`))
+	// grpc.NewClient is lazy; canceled ctx may or may not fail registration.
+	// Accept either outcome so we still exercise the call path.
+	_ = err
+}
+
+func TestRunInsecureGateway(t *testing.T) {
+	certPEM, keyPEM := mustTestCert(t)
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, serverConfig{
+			httpPort: port,
+			cert:     certPath,
+			key:      keyPath,
+			ca:       certPath,
+			insecure: true,
+			swagger:  []byte(`{"swagger":"2.0","info":{"title":"test","version":"0"},"paths":{}}`),
+		})
+	}()
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "localhost",
+		MinVersion:         tls.VersionTLS12,
+	}
+	waitHealthy(t, fmt.Sprintf("https://127.0.0.1:%d/healthz", port), tlsConfig)
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not shut down")
+	}
 }
 
 func waitHealthy(t *testing.T, url string, tlsConfig *tls.Config) {
@@ -219,6 +647,7 @@ func waitHealthy(t *testing.T, url string, tlsConfig *tls.Config) {
 		Transport: &http.Transport{TLSClientConfig: tlsConfig},
 	}
 	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
 	for {
 		resp, err := client.Get(url)
 		if err == nil {
@@ -226,9 +655,12 @@ func waitHealthy(t *testing.T, url string, tlsConfig *tls.Config) {
 			if resp.StatusCode == http.StatusOK {
 				return
 			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("server not healthy: %v", err)
+			t.Fatalf("server not healthy: %v", lastErr)
 		}
 		time.Sleep(25 * time.Millisecond)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes TLS mux behavior, probe paths, and in-cluster TLS wiring; mistakes could break rollouts or client TLS until the TLS secret and probes are configured correctly.
> 
> **Overview**
> Improves **helloworld** operability for Kubernetes and TLS clients: **`/healthz`**, gRPC health, HTTPS probes, TLS secret mounts, and clearer validation errors.
> 
> The service entrypoint is refactored so mux setup (`newMux`), env-based cert paths, and CA loading are testable. The in-process gRPC server no longer uses `grpc.Creds` on the mux path (TLS stays on `http.Server`); the gateway dials with a **host-only** `ServerName`, **TLS 1.2+**, and **`NextProtos`** includes **`http/1.1`** so kubelet HTTPS probes work alongside gRPC. **`SayHello`** empty-name errors now return **`InvalidArgument`** instead of a plain Go error.
> 
> **K8s** manifests switch liveness/readiness from **`/swagger.json`** to **`HTTPS /healthz`**, wire **`SSL_*`** env vars and a **`helloworld-tls`** volume, and drop Prometheus scrape annotations. Docs (**`README`**, **`AGENTS.md`**) note creating the TLS secret before deploy and updated Bazel test flags (`--config=race`).
> 
> **`cmd/helloworld-client`** mirrors the TLS `ServerName` fix. New integration tests cover mux HTTP/gRPC/REST and validation; server tests assert gRPC status codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eabd242bdbb9efc98044056402fab402510b670. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->